### PR TITLE
Use RFC5424 / RFC5426 syslog over UDP format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Ensure that syslogd has udp sockets enabled:
     ok
     3> syslog:notice(name, "other test").
     ok
+    4> syslog:send(name, "test 3", [{timestamp, os:timestamp()}]).
+    ok
 
 ### Logged
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
+## Overview
+
+This library writes messages formatted as per [RFC5424][rfc5424], transmitted
+via UDP as described in [RFC5426][rfc5426].
+
 ### Enable UDP
 
-Ensure that syslogd has udp sockets enabled:
-[OS X](http://stackoverflow.com/questions/1185554/how-to-enable-syslogd-to-receive-udp-logs-from-routers-in-osx)
+You can configure syslog-ng to receive these messages with the following directive:
+
+    syslog(transport("udp") port(514) keep_timestamp(yes));
 
 ### Build
 
@@ -9,7 +15,7 @@ Ensure that syslogd has udp sockets enabled:
 
 ### Log
 
-    0> syslog:start_link(name, tag, "localhost", 514, local0).
+    0> syslog:start_link(name, app_name, "localhost", 514, local0).
     ok
     2> syslog:send(name, "test").
     ok
@@ -22,5 +28,7 @@ Ensure that syslogd has udp sockets enabled:
 
     $ syslog
     ...
-    Tue Mar 16 18:36:48 192.168.1.101  tag[4294967295] <Info>: test
-    Tue Mar 16 18:36:57 192.168.1.101  tag[4294967295] <Notice>: other test
+    <134>1 2013-04-03T21:30:44.403394Z myhost.local app_name pid - - my log message
+
+[rfc5424]: http://tools.ietf.org/html/rfc5424 "RFC5424 - The Syslog Protocol"
+[rfc5426]: http://tools.ietf.org/html/rfc5426#section-3.1 "RFC5426 - Transmission of Syslog Messages over UDP"

--- a/src/syslog.app.src
+++ b/src/syslog.app.src
@@ -1,6 +1,6 @@
 {application, syslog, [
     {description, "Erlang syslog client"},
-    {vsn, "0.1"},
+    {vsn, "0.2"},
     {applications, [kernel, stdlib]},
     {registered, []}
 ]}.

--- a/src/syslog.erl
+++ b/src/syslog.erl
@@ -267,6 +267,12 @@ get_facility(Name) ->
     Facility = gen_server:call(Name, facility),
     facility(Facility).
 
+get_facility(Name, Opts) ->
+    case proplists:get_value(facility, Opts) of
+        undefined -> get_facility(Name);
+        Facility when is_integer(Facility) -> Facility
+    end.
+
 get_hostname(Opts) ->
     case proplists:get_value(hostname, Opts) of
         undefined ->
@@ -295,7 +301,7 @@ build_packet(Name, Msg, Opts) ->
     Hostname = get_hostname(Opts),
     Timestamp = get_timestamp(Opts),
 
-    Facility = get_facility(Name),
+    Facility = get_facility(Name, Opts),
     Level = get_level(Facility, Opts),
 
     Packet = [

--- a/src/syslog.erl
+++ b/src/syslog.erl
@@ -71,6 +71,9 @@ start_link(Name, AppName, Host, Port, Facility) when is_atom(Name), is_atom(AppN
 send(Msg) when is_list(Msg) ->
     send(?MODULE, Msg).
 
+send(Msg, Opts) when is_list(Msg), is_list(Opts) ->
+    send(?MODULE, Msg, []);
+
 send(Name, Msg) when is_list(Msg) ->
     send(Name, Msg, []).
 

--- a/src/syslog.erl
+++ b/src/syslog.erl
@@ -270,6 +270,7 @@ get_facility(Name) ->
 get_facility(Name, Opts) ->
     case proplists:get_value(facility, Opts) of
         undefined -> get_facility(Name);
+        Facility when is_atom(Facility) -> facility(Facility);
         Facility when is_integer(Facility) -> Facility
     end.
 

--- a/src/syslog.erl
+++ b/src/syslog.erl
@@ -264,9 +264,15 @@ get_facility(Name) ->
     Facility = gen_server:call(Name, facility),
     facility(Facility).
 
-get_hostname() ->
-    {ok, Host} = inet:gethostname(),
-    Host.
+get_hostname(Opts) ->
+    case proplists:get_value(hostname, Opts) of
+        undefined ->
+            {ok, Host} = inet:gethostname(),
+            Host;
+        Atom when is_atom(Atom) -> atom_to_list(Atom);
+        List when is_list(List) -> List;
+        Binary when is_binary(Binary) -> Binary
+    end.
 
 get_timestamp(Opts) when is_list(Opts) ->
     case proplists:get_value(timestamp, Opts) of
@@ -283,7 +289,7 @@ format_timestamp(TS) ->
 build_packet(Name, Msg, Opts) ->
     AppName = get_app_name(Name, Opts),
     Pid = get_pid(Opts),
-    Hostname = get_hostname(),
+    Hostname = get_hostname(Opts),
     Timestamp = get_timestamp(Opts),
 
     Facility = get_facility(Name),

--- a/src/syslog.erl
+++ b/src/syslog.erl
@@ -269,7 +269,7 @@ get_timestamp(Opts) when is_list(Opts) ->
 format_timestamp(TS) ->
     {{Y, M, D}, {H, MM, S}} = calendar:now_to_universal_time(TS),
     US = element(3, TS),
-    io_lib:format("~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.~6.10.0B+00:00",
+    io_lib:format("~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.~6.10.0BZ",
                   [Y,M,D, H,MM,S,US]).
 
 build_packet(Name, Msg, Opts) ->


### PR DESCRIPTION
Also adds timestamp and hostname options.

Note that this is likely backwards-incompatible for most users unless they change their syslog-ng configs. We should probably bump the version for it.
